### PR TITLE
prerequisite for arduino core rewrite

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -48,7 +48,12 @@ env.Append(
             ]), "Building $TARGET"),
             suffix=".bin"
         )
-    )
+    ),
+
+    LINKFLAGS=[
+        # don't care about RWX sections, we're running from flash anyway
+        "-Wl,--no-warn-rwx-segment",
+    ],
 )
 
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -25,12 +25,12 @@ env.Replace(
     SIZETOOL="arm-none-eabi-size",
 
     ARFLAGS=["rc"],
-
-    # TODO: section names are kinda guessed for the HC32F46x
-    SIZEPROGREGEXP=r"^(?:\.vectors|\.icg_sec|\.rodata|\.text|\.rodata|\.ARM.extab|\.ARM.exidx|\.preinit_array|\.init_array|\.fini_array|\.data)\s+(\d+).*",
-    SIZEDATAREGEXP=r"^(?:\.data|\.bss)\s+(\d+).*",
+    
     SIZECHECKCMD="$SIZETOOL -A -d $SOURCES",
     SIZEPRINTCMD="$SIZETOOL -B -d $SOURCES",
+    
+    # note: size regexprs are defined in framework build, as they
+    # depend on the linker script used
 
     PROGSUFFIX=".elf"
 )

--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
     "toolchain-gccarmnoneeabi": {
       "type": "toolchain",
       "owner": "platformio",
-      "version": ">=1.100301.220327"
+      "version": "=1.120201.221222"
     },
     "framework-arduino-hc32f46x": {
       "type": "framework",

--- a/platform.json
+++ b/platform.json
@@ -1,6 +1,6 @@
 {
   "name": "hc32f46x",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "title": "HC32F46X",
   "description": "HC32F46x",
   "homepage": "",


### PR DESCRIPTION
this PR introduces changes needed for the rewrite of `framework-arduino-hc32f46x` (https://github.com/shadow578/framework-arduino-hc32f46x/pull/4)