### PR TITLE
update toolchain-gccarmnoneeabi

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -33,7 +33,7 @@
     "toolchain-gccarmnoneeabi": {
       "type": "toolchain",
       "owner": "platformio",
-      "version": "=1.120201.221222"
+      "version": "=1.120301.0"
     },
     "framework-arduino-hc32f46x": {
       "type": "framework",


### PR DESCRIPTION
update toolchain-gccarmnoneabi to version `1.120301.0`, since version `1.120201.221222` has been removed.
see https://github.com/platformio/platformio-core/issues/4741#issuecomment-1731514133